### PR TITLE
current time counting method is wrong, fixed it

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,22 @@ Titan-X, batchsize = 1
 squeezenet : 0.003385
  mobilenet : 0.076977
 ```
-
+GTX-1080ti, batchsize = 16  (from [nebulaf91](https://github.com/nebulaf91))
+```
+  resnet18 : 0.008995
+   alexnet : 0.003605
+     vgg16 : 0.046771
+squeezenet : 0.010464
+ mobilenet : 0.010924
+```
+GTX-1080ti, batchsize = 1  (from [nebulaf91](https://github.com/nebulaf91))
+```
+  resnet18 : 0.002358
+   alexnet : 0.001373
+     vgg16 : 0.005438
+squeezenet : 0.001647
+ mobilenet : 0.001957
+```
 ---------
 
 ```

--- a/benchmark.py
+++ b/benchmark.py
@@ -5,6 +5,7 @@ import torch.backends.cudnn as cudnn
 import torchvision.models as models
 from torch.autograd import Variable
 
+
 class MobileNet(nn.Module):
     def __init__(self):
         super(MobileNet, self).__init__()
@@ -21,16 +22,16 @@ class MobileNet(nn.Module):
                 nn.Conv2d(inp, inp, 3, stride, 1, groups=inp, bias=False),
                 nn.BatchNorm2d(inp),
                 nn.ReLU(inplace=True),
-    
+
                 nn.Conv2d(inp, oup, 1, 1, 0, bias=False),
                 nn.BatchNorm2d(oup),
                 nn.ReLU(inplace=True),
             )
 
         self.model = nn.Sequential(
-            conv_bn(  3,  32, 2), 
-            conv_dw( 32,  64, 1),
-            conv_dw( 64, 128, 2),
+            conv_bn(3, 32, 2),
+            conv_dw(32, 64, 1),
+            conv_dw(64, 128, 2),
             conv_dw(128, 128, 1),
             conv_dw(128, 256, 2),
             conv_dw(256, 256, 1),
@@ -52,22 +53,26 @@ class MobileNet(nn.Module):
         x = self.fc(x)
         return x
 
+
 def speed(model, name):
     t0 = time.time()
-    input = torch.rand(1,3,224,224).cuda()
-    input = Variable(input, volatile = True)
+    input = torch.rand(1, 3, 224, 224).cuda()
+    input = Variable(input, volatile=True)
     t1 = time.time()
 
     model(input)
+    torch.cuda.synchronize()
     t2 = time.time()
 
     model(input)
+    torch.cuda.synchronize()
     t3 = time.time()
-    
+
     print('%10s : %f' % (name, t3 - t2))
 
+
 if __name__ == '__main__':
-    #cudnn.benchmark = True # This will make network slow ??
+    # cudnn.benchmark = True # This will make network slow ??
     resnet18 = models.resnet18().cuda()
     alexnet = models.alexnet().cuda()
     vgg16 = models.vgg16().cuda()


### PR DESCRIPTION
I found that in the current benchmark, vgg16 is faster than resnet18, which disagrees with my experience.
In pytorch, when counting time for GPU computation code, torch.cuda.synchronize() method is required. So i add it :), and now the time is right.
I also add benchmark results on my computer (GTX-1080ti), and maybe you should rerun the benchmark program to correct the results on your Titan-X.
Thank again you for your implementation of mobilenet in pytorch.